### PR TITLE
feat: replace native confirm dialogs with custom modal

### DIFF
--- a/web/src/components/ConfirmDeleteModal.jsx
+++ b/web/src/components/ConfirmDeleteModal.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Avatar
+} from '@mui/material';
+import { Warning as WarningIcon } from '@mui/icons-material';
+
+const ConfirmDeleteModal = ({ 
+  open, 
+  onClose, 
+  onConfirm, 
+  title = "Confirmar eliminación",
+  message = "¿Estás seguro de que quieres eliminar este elemento?",
+  itemName = "",
+  confirmText = "Eliminar",
+  cancelText = "Cancelar",
+  showItemName = true,
+  size = "sm" // "xs", "sm", "md"
+}) => {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Dialog 
+      open={open} 
+      onClose={onClose}
+      maxWidth={size}
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+          padding: size === "xs" ? 0.5 : 1
+        }
+      }}
+    >
+      <DialogTitle>
+        <Box display="flex" alignItems="center" gap={2}>
+          <Avatar sx={{ bgcolor: 'error.main' }}>
+            <WarningIcon />
+          </Avatar>
+          <Typography variant="h6" component="div">
+            {title}
+          </Typography>
+        </Box>
+      </DialogTitle>
+      
+      <DialogContent>
+        <Typography variant="body1" color="text.secondary">
+          {message}
+        </Typography>
+        {showItemName && itemName && (
+          <Box mt={2} p={2} bgcolor="grey.50" borderRadius={1}>
+            <Typography variant="body2" fontWeight="medium">
+              "{itemName}"
+            </Typography>
+          </Box>
+        )}
+        <Typography variant="body2" color="error.main" sx={{ mt: 2 }}>
+          Esta acción no se puede deshacer.
+        </Typography>
+      </DialogContent>
+      
+      <DialogActions sx={{ p: size === "xs" ? 2 : 3, gap: 1 }}>
+        <Button 
+          onClick={onClose}
+          variant="outlined"
+          sx={{ minWidth: size === "xs" ? 80 : 100 }}
+        >
+          {cancelText}
+        </Button>
+        <Button 
+          onClick={handleConfirm}
+          variant="contained"
+          color="error"
+          sx={{ minWidth: size === "xs" ? 80 : 100 }}
+        >
+          {confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/web/src/pages/DeckPage.jsx
+++ b/web/src/pages/DeckPage.jsx
@@ -34,6 +34,7 @@ import {
 import { useApi } from '../contexts/ApiContext';
 import Navigation from '../components/Navigation';
 import AIFlashcardsGenerator from '../components/AIFlashcardsGenerator';
+import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 
 const DeckPage = () => {
   const { deckId } = useParams();
@@ -62,6 +63,10 @@ const DeckPage = () => {
   const [reviewDialogOpen, setReviewDialogOpen] = useState(false);
   const [reviewingCard, setReviewingCard] = useState(null);
   const [showAnswer, setShowAnswer] = useState(false);
+
+  // Modal para confirmar eliminación
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [cardToDelete, setCardToDelete] = useState(null);
 
   useEffect(() => {
     loadDeckAndCards();
@@ -135,10 +140,16 @@ const DeckPage = () => {
   };
 
   const handleDeleteCard = async (cardId) => {
-    if (!window.confirm('¿Estás seguro de que quieres eliminar esta flashcard?')) return;
+    const card = cards.find(c => c.id === cardId);
+    setCardToDelete(card);
+    setDeleteDialogOpen(true);
+  };
+
+  const confirmDeleteCard = async () => {
+    if (!cardToDelete) return;
 
     try {
-      await flashcards.delete(cardId);
+      await flashcards.delete(cardToDelete.id);
       loadDeckAndCards();
     } catch (err) {
       console.error('Error deleting flashcard:', err);
@@ -482,6 +493,22 @@ const DeckPage = () => {
           open={aiGeneratorOpen}
           onClose={() => setAiGeneratorOpen(false)}
           onGenerate={handleGeneratedCards}
+        />
+
+        {/* Modal para confirmar eliminación */}
+        <ConfirmDeleteModal
+          open={deleteDialogOpen}
+          onClose={() => {
+            setDeleteDialogOpen(false);
+            setCardToDelete(null);
+          }}
+          onConfirm={confirmDeleteCard}
+          title="Eliminar Flashcard"
+          message="¿Estás seguro de que quieres eliminar esta flashcard?"
+          showItemName={false}
+          confirmText="Eliminar"
+          cancelText="Cancelar"
+          size="xs"
         />
       </Container>
     </>

--- a/web/src/pages/HomePage.jsx
+++ b/web/src/pages/HomePage.jsx
@@ -35,6 +35,7 @@ import {
 } from '@mui/icons-material';
 import { useApi } from '../contexts/ApiContext';
 import Navigation from '../components/Navigation';
+import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -52,6 +53,10 @@ const HomePage = () => {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editingDeck, setEditingDeck] = useState(null);
   const [editing, setEditing] = useState(false);
+
+  // Modal para confirmar eliminación
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deckToDelete, setDeckToDelete] = useState(null);
 
   useEffect(() => {
     loadDecks();
@@ -104,10 +109,16 @@ const HomePage = () => {
   };
 
   const handleDeleteDeck = async (deckId) => {
-    if (!window.confirm('¿Estás seguro de que quieres eliminar este deck?')) return;
+    const deck = decksList.find(d => d.id === deckId);
+    setDeckToDelete(deck);
+    setDeleteDialogOpen(true);
+  };
+
+  const confirmDeleteDeck = async () => {
+    if (!deckToDelete) return;
 
     try {
-      await decks.delete(deckId);
+      await decks.delete(deckToDelete.id);
       loadDecks();
     } catch (err) {
       console.error('Error deleting deck:', err);
@@ -484,6 +495,22 @@ const HomePage = () => {
             </Button>
           </DialogActions>
         </Dialog>
+
+        {/* Modal para confirmar eliminación */}
+        <ConfirmDeleteModal
+          open={deleteDialogOpen}
+          onClose={() => {
+            setDeleteDialogOpen(false);
+            setDeckToDelete(null);
+          }}
+          onConfirm={confirmDeleteDeck}
+          title="Eliminar Deck"
+          message="¿Estás seguro de que quieres eliminar este deck?"
+          showItemName={false}
+          confirmText="Eliminar"
+          cancelText="Cancelar"
+          size="xs"
+        />
       </Container>
     </>
   );


### PR DESCRIPTION
- Add ConfirmDeleteModal component with Material-UI design
- Replace window.confirm() in HomePage and DeckPage
- Make modal configurable (size, showItemName props)
- Improve UX with consistent styling and better accessibility