### PR TITLE
Feature/fix UI details

### DIFF
--- a/web/src/contexts/ApiContext.jsx
+++ b/web/src/contexts/ApiContext.jsx
@@ -40,7 +40,8 @@ export const ApiProvider = ({ children }) => {
   const flashcards = {
     getAll: () => api.get('/flashcards'),
     getById: (id) => api.get(`/flashcards/${id}`),
-    getByDeck: (deckId) => api.get(`/flashcards/deck/${deckId}`),
+    getByDeck: (deckId, { page = 0, pageSize = 15 } = {}) =>
+      api.get(`/flashcards/deck/${deckId}`, { params: { page, pageSize } }),
     getDue: () => api.get('/flashcards/due'),
     create: (data) => api.post('/flashcards', data),
     createMany: (flashcards) => api.post('/flashcards/batch', { flashcards }),

--- a/web/src/pages/DeckPage.jsx
+++ b/web/src/pages/DeckPage.jsx
@@ -26,7 +26,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Paper
+  Paper,
+  TablePagination
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -49,6 +50,7 @@ const DeckPage = () => {
 
   const [deck, setDeck] = useState(null);
   const [cards, setCards] = useState([]);
+  const [totalCards, setTotalCards] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -73,19 +75,21 @@ const DeckPage = () => {
   const [showAnswer, setShowAnswer] = useState(false);
 
   useEffect(() => {
-    loadDeckAndCards();
-  }, [deckId]);
+    loadDeckAndCards(page, rowsPerPage);
+    // eslint-disable-next-line
+  }, [deckId, page, rowsPerPage]);
 
-  const loadDeckAndCards = async () => {
+  const loadDeckAndCards = async (page = 0, pageSize = 15) => {
     try {
       setLoading(true);
       const [deckResponse, cardsResponse] = await Promise.all([
         decks.getById(deckId),
-        flashcards.getByDeck(deckId)
+        flashcards.getByDeck(deckId, { page, pageSize })
       ]);
 
       setDeck(deckResponse.data.data);
       setCards(cardsResponse.data.data || []);
+      setTotalCards(cardsResponse.data.total || 0);
       setError(null);
     } catch (err) {
       setError('Error al cargar el deck y las flashcards');
@@ -106,7 +110,7 @@ const DeckPage = () => {
       });
       setCreateDialogOpen(false);
       setNewCard({ front: '', back: '' });
-      loadDeckAndCards();
+  loadDeckAndCards(page, rowsPerPage);
     } catch (err) {
       console.error('Error creating flashcard:', err);
     } finally {
@@ -121,7 +125,7 @@ const DeckPage = () => {
         deckId: parseInt(deckId)
       }));
       await flashcards.createMany(cardsWithDeckId);
-      loadDeckAndCards();
+  loadDeckAndCards(page, rowsPerPage);
     } catch (err) {
       console.error('Error creating generated flashcards:', err);
     }
@@ -135,7 +139,7 @@ const DeckPage = () => {
       await flashcards.update(editingCard.id, editingCard);
       setEditDialogOpen(false);
       setEditingCard(null);
-      loadDeckAndCards();
+  loadDeckAndCards(page, rowsPerPage);
     } catch (err) {
       console.error('Error editing flashcard:', err);
     } finally {
@@ -148,7 +152,7 @@ const DeckPage = () => {
 
     try {
       await flashcards.delete(cardId);
-      loadDeckAndCards();
+  loadDeckAndCards(page, rowsPerPage);
     } catch (err) {
       console.error('Error deleting flashcard:', err);
     }
@@ -162,7 +166,7 @@ const DeckPage = () => {
       setReviewDialogOpen(false);
       setReviewingCard(null);
       setShowAnswer(false);
-      loadDeckAndCards();
+  loadDeckAndCards(page, rowsPerPage);
     } catch (err) {
       console.error('Error reviewing flashcard:', err);
     }
@@ -251,7 +255,7 @@ const DeckPage = () => {
           </Alert>
         )}
 
-        <TableContainer 
+  <TableContainer 
           component={Paper} 
           sx={{ 
             backgroundColor: 'grey.900',
@@ -315,6 +319,16 @@ const DeckPage = () => {
               })}
             </TableBody>
           </Table>
+          <TablePagination
+            rowsPerPageOptions={[15]}
+            component="div"
+            count={totalCards}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={(event, newPage) => setPage(newPage)}
+            onRowsPerPageChange={() => {}}
+            labelRowsPerPage="Flashcards por página"
+          />
         </TableContainer>
 
         {cards.length === 0 && !loading && (


### PR DESCRIPTION
This pull request introduces pagination for flashcards within a deck and updates the deck page to display flashcards in a paginated table format. The changes improve scalability and user experience when viewing large decks by limiting the number of flashcards shown at once and providing navigation controls.

**Pagination support and API changes:**

* Updated the `flashcards.getByDeck` method in `ApiContext.jsx` to accept pagination parameters (`page`, `pageSize`) and pass them to the API, enabling backend support for paginated flashcard retrieval.

**Deck page UI and logic updates:**

* Refactored the deck page to use a Material UI table (`Table`, `TableBody`, `TableCell`, etc.) instead of a grid of cards, providing a more organized and scalable display of flashcards. [[1]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L22-R30) [[2]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L245-R332)
* Added state variables (`page`, `rowsPerPage`, `totalCards`) and integrated `TablePagination` to manage and display paginated flashcards, including updating the `loadDeckAndCards` function to fetch the correct page of data. [[1]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31R53) [[2]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31R71-R92)
* Updated all flashcard CRUD operations (create, edit, delete, review) to reload the current page of flashcards after each operation, ensuring the UI remains in sync with the backend. [[1]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L100-R113) [[2]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L115-R128) [[3]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L129-R142) [[4]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L142-R155) [[5]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L156-R169)