### PR TITLE
fix: remove duplicate theme keys in ThemeContext.jsx

### DIFF
--- a/web/src/contexts/ThemeContext.jsx
+++ b/web/src/contexts/ThemeContext.jsx
@@ -81,105 +81,60 @@ const tokyoTheme = Object.assign(
 );
 
 const themes = {
-  light: createTheme({
-    palette: {
-      mode: 'light',
-      primary: { main: '#1976d2' },
-      secondary: { main: '#9c27b0' },
-      background: {
-        default: '#f7f9fa',
-        paper: '#fdfdfd'
-      },
-      divider: '#e0e0e0',
-      action: {
-        hover: '#f0f4f8'
-      },
-      text: {
-        primary: '#222',
-        secondary: '#444'
-      },
-      icon: {
-        main: '#222'
+  light: Object.assign(
+    createTheme({
+      palette: {
+        mode: 'light',
+        primary: { main: '#1976d2' },
+        secondary: { main: '#9c27b0' },
+        background: {
+          default: '#f7f9fa',
+          paper: '#fdfdfd'
+        },
+        divider: '#e0e0e0',
+        action: {
+          hover: '#f0f4f8'
+        },
+        text: {
+          primary: '#222',
+          secondary: '#444'
+        },
+        icon: {
+          main: '#222'
+        }
       }
-    }
-  }),
-    light: Object.assign(
-      createTheme({
-        palette: {
-          mode: 'light',
-          primary: { main: '#1976d2' },
-          secondary: { main: '#9c27b0' },
-          background: {
-            default: '#f7f9fa',
-            paper: '#fdfdfd'
-          },
-          divider: '#e0e0e0',
-          action: {
-            hover: '#f0f4f8'
-          },
-          text: {
-            primary: '#222',
-            secondary: '#444'
-          },
-          icon: {
-            main: '#222'
-          }
-        }
-      }),
-      { fontFamily: 'Roboto, Arial, sans-serif' }
-    ),
-  dark: createTheme({
-    palette: {
-      mode: 'dark',
-      primary: { main: '#90caf9' },
-      secondary: { main: '#ce93d8' },
-      background: { default: '#1e1e1e', paper: '#2d2d2d' },
-      grey: { 800: '#333333', 900: '#1e1e1e' }
-    }
-  }),
-    dark: Object.assign(
-      createTheme({
-        palette: {
-          mode: 'dark',
-          primary: { main: '#90caf9' },
-          secondary: { main: '#ce93d8' },
-          background: { default: '#1e1e1e', paper: '#2d2d2d' },
-          grey: { 800: '#333333', 900: '#1e1e1e' }
-        }
-      }),
-      { fontFamily: 'Roboto, Arial, sans-serif' }
-    ),
-  github: createTheme({
-    palette: {
-      mode: 'dark',
-      primary: { main: '#2ea44f' },
-      secondary: { main: '#24292f' },
-      background: { default: '#0d1117', paper: '#161b22' },
-      text: { primary: '#c9d1d9', secondary: '#8b949e' },
-      grey: { 800: '#21262d', 900: '#0d1117' },
-      info: { main: '#58a6ff' },
-      warning: { main: '#f6c343' },
-      error: { main: '#f85149' },
-      success: { main: '#2ea44f' }
-    }
-  }),
-    github: Object.assign(
-      createTheme({
-        palette: {
-          mode: 'dark',
-          primary: { main: '#2ea44f' },
-          secondary: { main: '#24292f' },
-          background: { default: '#0d1117', paper: '#161b22' },
-          text: { primary: '#c9d1d9', secondary: '#8b949e' },
-          grey: { 800: '#21262d', 900: '#0d1117' },
-          info: { main: '#58a6ff' },
-          warning: { main: '#f6c343' },
-          error: { main: '#f85149' },
-          success: { main: '#2ea44f' }
-        }
-      }),
-      { fontFamily: 'Roboto Mono, Fira Mono, Menlo, Monaco, Consolas, monospace' }
-    ),
+    }),
+    { fontFamily: 'Roboto, Arial, sans-serif' }
+  ),
+  dark: Object.assign(
+    createTheme({
+      palette: {
+        mode: 'dark',
+        primary: { main: '#90caf9' },
+        secondary: { main: '#ce93d8' },
+        background: { default: '#1e1e1e', paper: '#2d2d2d' },
+        grey: { 800: '#333333', 900: '#1e1e1e' }
+      }
+    }),
+    { fontFamily: 'Roboto, Arial, sans-serif' }
+  ),
+  github: Object.assign(
+    createTheme({
+      palette: {
+        mode: 'dark',
+        primary: { main: '#2ea44f' },
+        secondary: { main: '#24292f' },
+        background: { default: '#0d1117', paper: '#161b22' },
+        text: { primary: '#c9d1d9', secondary: '#8b949e' },
+        grey: { 800: '#21262d', 900: '#0d1117' },
+        info: { main: '#58a6ff' },
+        warning: { main: '#f6c343' },
+        error: { main: '#f85149' },
+        success: { main: '#2ea44f' }
+      }
+    }),
+    { fontFamily: 'Roboto Mono, Fira Mono, Menlo, Monaco, Consolas, monospace' }
+  ),
   tokyo: tokyoTheme,
   kyoto: kyotoTheme
 };


### PR DESCRIPTION
- Remove duplicate 'light', 'dark', and 'github' keys from themes object
- Keep enhanced versions with fontFamily property
- Resolve vite warnings about duplicate keys