### PR TITLE
Feature/search component

### DIFF
--- a/web/src/components/CardRow.jsx
+++ b/web/src/components/CardRow.jsx
@@ -52,6 +52,9 @@ const CardRow = ({
         {card.front.length > 25 ? card.front.substring(0, 25) + '…' : card.front}
       </TableCell>
       <TableCell sx={{ py: 1.5 }}>
+        {/* Columna de búsqueda - vacía en las filas de datos */}
+      </TableCell>
+      <TableCell sx={{ py: 1.5 }}>
         <TagCrud
           card={card}
           tags={tags}

--- a/web/src/components/FlashcardTable.jsx
+++ b/web/src/components/FlashcardTable.jsx
@@ -7,9 +7,11 @@ import {
   TableBody,
   TablePagination,
   TableContainer,
-  Typography
+  Typography,
+  Box
 } from '@mui/material';
 import CardRow from './CardRow';
+import SearchBar from './SearchBar';
 
 const FlashcardTable = ({
   cards,
@@ -21,6 +23,9 @@ const FlashcardTable = ({
   searchQuery,
   searchResults,
   searchTotal,
+  searching,
+  onSearchChange,
+  onClearSearch,
   openReviewDialog,
   openEditDialog,
   handleDeleteCard,
@@ -61,6 +66,27 @@ const FlashcardTable = ({
                 sx={{ color: safeMuiTheme.palette?.text?.secondary, fontSize: '0.875rem', py: 1.5 }}
               >
                 Consigna
+              </TableCell>
+              <TableCell
+                sx={{
+                  color: safeMuiTheme.palette?.text?.secondary,
+                  fontSize: '0.875rem',
+                  py: 1.5,
+                  minWidth: 200
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="inherit">Buscar</Typography>
+                  <SearchBar
+                    searchQuery={searchQuery || ''}
+                    onSearchChange={onSearchChange}
+                    onClearSearch={onClearSearch}
+                    searching={searching}
+                    placeholder="Buscar flashcards..."
+                    label=""
+                    size="small"
+                  />
+                </Box>
               </TableCell>
               <TableCell
                 sx={{ color: safeMuiTheme.palette?.text?.secondary, fontSize: '0.875rem', py: 1.5 }}
@@ -109,7 +135,7 @@ const FlashcardTable = ({
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={5} align="center" sx={{ py: 6 }}>
+                <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
                   <Typography variant="body1" color="text.secondary">
                     {searchQuery
                       ? 'No se encontraron flashcards con esa búsqueda'

--- a/web/src/components/SearchBar.jsx
+++ b/web/src/components/SearchBar.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  TextField,
+  InputAdornment,
+  IconButton,
+  CircularProgress,
+  useTheme as useMuiTheme
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  Clear as ClearIcon
+} from '@mui/icons-material';
+
+const SearchBar = ({
+  searchQuery,
+  onSearchChange,
+  onClearSearch,
+  searching = false,
+  disabled = false,
+  placeholder = "Buscar...",
+  label = "Buscar",
+  size = "small"
+}) => {
+  const muiTheme = useMuiTheme();
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <TextField
+      size={size}
+      variant="outlined"
+      label={label}
+      placeholder={placeholder}
+      value={searchQuery}
+      onChange={onSearchChange}
+      onKeyPress={handleKeyPress}
+      disabled={disabled}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon color="action" fontSize="small" />
+          </InputAdornment>
+        ),
+        endAdornment: searchQuery ? (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              onClick={onClearSearch}
+              disabled={disabled}
+              sx={{ mr: 0.5 }}
+            >
+              <ClearIcon fontSize="small" />
+            </IconButton>
+            {searching && <CircularProgress size={16} />}
+          </InputAdornment>
+        ) : (
+          searching && <CircularProgress size={16} />
+        )
+      }}
+      sx={{
+        '& .MuiInputBase-root': {
+          fontFamily: muiTheme.fontFamily,
+          fontSize: '0.875rem'
+        },
+        '& .MuiInputLabel-root': {
+          fontFamily: muiTheme.fontFamily,
+          fontSize: '0.8rem'
+        },
+        '& .MuiFormHelperText-root': {
+          fontFamily: muiTheme.fontFamily,
+          fontSize: '0.75rem'
+        },
+        minWidth: 200,
+        maxWidth: 300
+      }}
+    />
+  );
+};
+
+export default SearchBar;

--- a/web/src/pages/DeckPage.jsx
+++ b/web/src/pages/DeckPage.jsx
@@ -335,13 +335,13 @@ const DeckPage = () => {
       >
         {/* Información del deck */}
         {deck && (
-          <Box sx={{ mb: 3 }}>
+          <Box sx={{ mb: 1 }}>
             <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: muiTheme.fontFamily }}>
               {deck.name}
             </Typography>
             {deck.description && (
               <Typography variant="body1" color="text.secondary" sx={{ fontFamily: muiTheme.fontFamily }}>
-                {deck.description}
+                descripción: {deck.description}
               </Typography>
             )}
           </Box>
@@ -355,7 +355,7 @@ const DeckPage = () => {
         )}
 
         {/* Componente de búsqueda */}
-        <Box sx={{ mb: 3, display: 'flex', justifyContent: 'center' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'left' }}>
           <Paper
             elevation={1}
             sx={{
@@ -363,7 +363,7 @@ const DeckPage = () => {
               backgroundColor: muiTheme.palette.background.paper,
               borderRadius: 2,
               width: 400,
-              maxWidth: '90%'
+              maxWidth: '20%'
             }}
           >
             <TextField

--- a/web/src/pages/DeckPage.jsx
+++ b/web/src/pages/DeckPage.jsx
@@ -355,63 +355,64 @@ const DeckPage = () => {
         )}
 
         {/* Componente de búsqueda */}
-        <Paper
-          elevation={1}
-          sx={{
-            p: 2,
-            mb: 3,
-            backgroundColor: muiTheme.palette.background.paper,
-            borderRadius: 2
-          }}
-        >
-          <TextField
-            fullWidth
-            variant="outlined"
-            label="Buscar flashcards en este deck"
-            placeholder="Ingresa términos de búsqueda..."
-            value={searchQuery}
-            onChange={handleSearchInputChange}
-            disabled={loading}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon color="action" />
-                </InputAdornment>
-              ),
-              endAdornment: searchQuery ? (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    onClick={handleClearSearch}
-                    disabled={loading}
-                    sx={{ mr: 0.5 }}
-                  >
-                    <ClearIcon />
-                  </IconButton>
-                  {searching && <CircularProgress size={20} />}
-                </InputAdornment>
-              ) : (
-                searching && <CircularProgress size={20} />
-              )
-            }}
-            helperText={
-              searchQuery
-                ? `${searchTotal} resultado${searchTotal !== 1 ? 's' : ''} encontrado${searchTotal !== 1 ? 's' : ''}`
-                : "Busca en las preguntas de las flashcards"
-            }
+        <Box sx={{ mb: 3, display: 'flex', justifyContent: 'center' }}>
+          <Paper
+            elevation={1}
             sx={{
-              '& .MuiInputBase-root': {
-                fontFamily: muiTheme.fontFamily
-              },
-              '& .MuiInputLabel-root': {
-                fontFamily: muiTheme.fontFamily
-              },
-              '& .MuiFormHelperText-root': {
-                fontFamily: muiTheme.fontFamily
-              }
+              p: 1.5,
+              backgroundColor: muiTheme.palette.background.paper,
+              borderRadius: 2,
+              width: 400,
+              maxWidth: '90%'
             }}
-          />
-        </Paper>
+          >
+            <TextField
+              size="small"
+              variant="outlined"
+              label="Buscar flashcards"
+              placeholder="Buscar..."
+              value={searchQuery}
+              onChange={handleSearchInputChange}
+              disabled={loading}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon color="action" fontSize="small" />
+                  </InputAdornment>
+                ),
+                endAdornment: searchQuery ? (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={handleClearSearch}
+                      disabled={loading}
+                      sx={{ mr: 0.5 }}
+                    >
+                      <ClearIcon fontSize="small" />
+                    </IconButton>
+                    {searching && <CircularProgress size={16} />}
+                  </InputAdornment>
+                ) : (
+                  searching && <CircularProgress size={16} />
+                )
+              }}
+              sx={{
+                '& .MuiInputBase-root': {
+                  fontFamily: muiTheme.fontFamily,
+                  fontSize: '0.875rem'
+                },
+                '& .MuiInputLabel-root': {
+                  fontFamily: muiTheme.fontFamily,
+                  fontSize: '0.8rem'
+                },
+                '& .MuiFormHelperText-root': {
+                  fontFamily: muiTheme.fontFamily,
+                  fontSize: '0.75rem'
+                }
+              }}
+            />
+          </Paper>
+        </Box>
 
         {(themeName === 'kyoto' || themeName === 'tokyo') && (
           <Box

--- a/web/src/pages/DeckPage.jsx
+++ b/web/src/pages/DeckPage.jsx
@@ -10,18 +10,12 @@ import {
   useTheme as useMuiTheme,
   Fab,
   Tooltip,
-  TextField,
-  InputAdornment,
-  IconButton,
-  Typography,
-  Paper
+  Typography
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
   AddCard as AddCardIcon,
-  SmartToy as AIIcon,
-  Search as SearchIcon,
-  Clear as ClearIcon
+  SmartToy as AIIcon
 } from '@mui/icons-material';
 import { useApi } from '../contexts/ApiContext';
 import Navigation from '../components/Navigation';
@@ -354,65 +348,6 @@ const DeckPage = () => {
           </Alert>
         )}
 
-        {/* Componente de búsqueda */}
-        <Box sx={{ display: 'flex', justifyContent: 'left' }}>
-          <Paper
-            elevation={1}
-            sx={{
-              p: 1.5,
-              backgroundColor: muiTheme.palette.background.paper,
-              borderRadius: 2,
-              width: 400,
-              maxWidth: '20%'
-            }}
-          >
-            <TextField
-              size="small"
-              variant="outlined"
-              label="Buscar flashcards"
-              placeholder="Buscar..."
-              value={searchQuery}
-              onChange={handleSearchInputChange}
-              disabled={loading}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon color="action" fontSize="small" />
-                  </InputAdornment>
-                ),
-                endAdornment: searchQuery ? (
-                  <InputAdornment position="end">
-                    <IconButton
-                      size="small"
-                      onClick={handleClearSearch}
-                      disabled={loading}
-                      sx={{ mr: 0.5 }}
-                    >
-                      <ClearIcon fontSize="small" />
-                    </IconButton>
-                    {searching && <CircularProgress size={16} />}
-                  </InputAdornment>
-                ) : (
-                  searching && <CircularProgress size={16} />
-                )
-              }}
-              sx={{
-                '& .MuiInputBase-root': {
-                  fontFamily: muiTheme.fontFamily,
-                  fontSize: '0.875rem'
-                },
-                '& .MuiInputLabel-root': {
-                  fontFamily: muiTheme.fontFamily,
-                  fontSize: '0.8rem'
-                },
-                '& .MuiFormHelperText-root': {
-                  fontFamily: muiTheme.fontFamily,
-                  fontSize: '0.75rem'
-                }
-              }}
-            />
-          </Paper>
-        </Box>
 
         {(themeName === 'kyoto' || themeName === 'tokyo') && (
           <Box
@@ -438,6 +373,9 @@ const DeckPage = () => {
           searchQuery={searchQuery}
           searchResults={searchResults}
           searchTotal={searchTotal}
+          searching={searching}
+          onSearchChange={handleSearchInputChange}
+          onClearSearch={handleClearSearch}
           openReviewDialog={openReviewDialog}
           openEditDialog={openEditDialog}
           handleDeleteCard={handleDeleteCard}


### PR DESCRIPTION
This pull request adds a search bar to the flashcards table, enabling users to search for flashcards within a deck. It introduces a new `SearchBar` component, updates the table layout to include a search column, and implements debounced search logic in the deck page. The changes also improve the deck page's structure by displaying deck information and error messages more clearly.

**Search Functionality Integration:**

* Added a new `SearchBar` component (`web/src/components/SearchBar.jsx`) with support for live input, clear button, loading indicator, and Material UI styling.
* Updated `FlashcardTable` to include a "Buscar" (Search) column in the table header and a corresponding empty cell in each data row, integrating the `SearchBar` component and related props for search state and handlers. [[1]](diffhunk://#diff-3f6bc5097e4faf738a86652bbeaee1f715e75a0befdffe47c0314dac1fb63fb8R70-R90) [[2]](diffhunk://#diff-d99e0483b8b903b9707418f36e056ab7cce860e7e90a8eb30c92519a4000de1dR54-R56) [[3]](diffhunk://#diff-3f6bc5097e4faf738a86652bbeaee1f715e75a0befdffe47c0314dac1fb63fb8R26-R28) [[4]](diffhunk://#diff-3f6bc5097e4faf738a86652bbeaee1f715e75a0befdffe47c0314dac1fb63fb8L10-R14) [[5]](diffhunk://#diff-3f6bc5097e4faf738a86652bbeaee1f715e75a0befdffe47c0314dac1fb63fb8L112-R138)

**Deck Page Logic and UI Enhancements:**

* Implemented debounced search logic in `DeckPage` using `handleSearchInputChange`, including clearing and restoring results, handling pagination during search, and cleaning up timeouts on unmount. [[1]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L46-R48) [[2]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31R139-R176) [[3]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31R259-R267) [[4]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31R376-R382)
* Improved deck page layout by displaying deck name, description, and error messages above the flashcards table. [[1]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L282-R351) [[2]](diffhunk://#diff-8336d55afe4979ac84b6b20d97f58ecaf3fb7f2816d09ad3dd89921304ab3f31L12-R13)