### PR TITLE
refactor(ci): streamline CI workflow by removing backend and integrat…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,82 +7,9 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  backend-tests:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      working-directory: ./server
-      run: npm install
-
-    - name: Run tests
-      working-directory: ./server
-      run: npm test
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    needs: backend-tests
-    if: ${{ github.event_name == 'pull_request' }}
-
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: testpassword
-          POSTGRES_DB: testdb
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - name: Install dependencies
-      working-directory: ./server
-      run: npm install
-
-    - name: Create test environment file
-      working-directory: ./server
-      run: |
-        echo "NODE_ENV=test" > .env
-        echo "DATABASE_URL=postgresql://postgres:testpassword@localhost:5432/testdb" >> .env
-        echo "DIRECT_URL=postgresql://postgres:testpassword@localhost:5432/testdb" >> .env  
-        echo "JWT_SECRET=test_jwt_secret_key_for_ci" >> .env
-        echo "OPENAI_API_KEY=test_key" >> .env
-
-
-    - name: Run database migrations
-      working-directory: ./server
-      run: npx prisma migrate deploy
-
-    - name: Run integration tests
-      working-directory: ./server
-      run: npm run test:integration
-
   deploy:
     name: Deploy to VPS
     runs-on: ubuntu-latest
-    needs: integration-tests
     environment: hostinger
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
 
@@ -115,8 +42,12 @@ jobs:
           npx prisma migrate deploy
           npx prisma generate
 
+          echo "➡️ Instalando dependencias del frontend..."
+          cd /root/ia-mvp/web
+          npm install
+
           echo "➡️ Iniciando servicios Backend y Frontend con Screen..."
-          cd ../
+          cd /root/ia-mvp
           chmod +x start_services_screen.sh
           ./start_services_screen.sh
           echo "✅ Servicios levantados con Screen"

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node server.js",
+    "dev:vite": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .js,.jsx",
@@ -19,6 +20,7 @@
     "@mui/material": "^7.3.2",
     "axios": "^1.11.0",
     "canvas-confetti": "^1.9.4",
+    "express": "^4.18.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.8.2"

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,56 @@
+import express from 'express';
+import { createServer as createViteServer } from 'vite';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const app = express();
+const PORT = process.env.PORT || 5173;
+
+// Redirigir acceso directo por IP a icards.fun
+app.use((req, res, next) => {
+  const host = req.get('host') || '';
+  const isICardsDomain = host.includes('icards.fun');
+  
+  // Si NO acceden por icards.fun (acceso directo por IP), redirigir
+  // Pero NO redirigir rutas de API (necesitan funcionar para el proxy)
+  if (!isICardsDomain && !req.path.startsWith('/api')) {
+    const fullUrl = `https://icards.fun${req.path}${req.query ? '?' + new URLSearchParams(req.query).toString() : ''}`;
+    return res.redirect(301, fullUrl);
+  }
+  
+  next();
+});
+
+async function createServer() {
+  // En desarrollo, crear servidor Vite
+  if (process.env.NODE_ENV !== 'production') {
+    // Vite carga automáticamente vite.config.js, incluyendo el proxy de /api
+    const vite = await createViteServer({
+      server: { middlewareMode: true },
+      appType: 'spa',
+    });
+
+    // Usar el middleware de Vite para desarrollo (incluye el proxy de /api configurado en vite.config.js)
+    app.use(vite.middlewares);
+  } else {
+    // En producción, servir archivos estáticos
+    app.use(express.static(resolve(__dirname, 'dist')));
+    app.get('*', (req, res) => {
+      res.sendFile(resolve(__dirname, 'dist', 'index.html'));
+    });
+  }
+
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`🚀 Servidor corriendo en http://0.0.0.0:${PORT}`);
+    console.log(`🔄 Redirecciones activas: Todas las rutas -> https://icards.fun (excepto /api)`);
+  });
+}
+
+createServer().catch((err) => {
+  console.error('Error al iniciar servidor:', err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
This pull request updates the frontend build and deployment process, introduces a custom Express server for the frontend, and modifies the CI workflow to streamline job execution. The changes focus on improving how the frontend is served in both development and production, adding domain-based redirection logic, and simplifying CI job dependencies.

**Frontend server improvements:**

* Added a new `web/server.js` file that sets up an Express server to serve the frontend, including logic to redirect direct IP access to the `icards.fun` domain except for API routes. It also integrates Vite middleware in development and serves static files in production.
* Updated `web/package.json` to use `node server.js` as the default development script, added a separate `dev:vite` script, and included `express` as a dependency. [[1]](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceL7-R8) [[2]](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceR23)

**CI/CD workflow changes:**

* Removed the `backend-tests` and `integration-tests` jobs from `.github/workflows/ci.yml`, making the `deploy` job independent of test job completion. This change streamlines the deployment process and removes test gating for deployment.
* Updated the deployment job in the CI workflow to explicitly install frontend dependencies in `/root/ia-mvp/web` before starting backend and frontend services.…ion tests; update frontend package.json for new dev script