### PR TITLE
feat: add SSE proxy configuration for MCP Server on ports 3001 in Nginx

### DIFF
--- a/nginx/icards.fun.conf.http
+++ b/nginx/icards.fun.conf.http
@@ -16,6 +16,25 @@ server {
     # Tamaño máximo de archivos
     client_max_body_size 10M;
 
+    # Proxy para MCP Server SSE (puerto 3001)
+    location /sse {
+        proxy_pass http://localhost:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Configuración especial para Server-Sent Events (SSE)
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+        proxy_connect_timeout 24h;
+        proxy_send_timeout 24h;
+        # Headers para SSE
+        add_header Cache-Control 'no-cache';
+        add_header X-Accel-Buffering 'no';
+    }
+
     # Proxy para API Backend (puerto 3000)
     location /api {
         proxy_pass http://localhost:3000;

--- a/nginx/icards.fun.conf.https
+++ b/nginx/icards.fun.conf.https
@@ -40,6 +40,25 @@ server {
     # Tamaño máximo de archivos
     client_max_body_size 10M;
 
+    # Proxy para MCP Server SSE (puerto 3001)
+    location /sse {
+        proxy_pass http://localhost:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Configuración especial para Server-Sent Events (SSE)
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+        proxy_connect_timeout 24h;
+        proxy_send_timeout 24h;
+        # Headers para SSE
+        add_header Cache-Control 'no-cache';
+        add_header X-Accel-Buffering 'no';
+    }
+
     # Proxy para API Backend (puerto 3000)
     location /api {
         proxy_pass http://localhost:3000;


### PR DESCRIPTION
This pull request updates the Nginx configuration to support proxying Server-Sent Events (SSE) from the MCP Server on port 3001. The changes ensure proper handling and delivery of SSE streams by disabling buffering and setting appropriate headers and timeouts.

**SSE Proxy Configuration:**

* Added a new `location /sse` block to both `nginx/icards.fun.conf.http` and `nginx/icards.fun.conf.https` to proxy requests to `http://localhost:3001`, with headers and settings specifically tailored for SSE, including disabling buffering and cache, and extending timeouts for persistent connections. [[1]](diffhunk://#diff-4c31f81ae71e5222a6a925a9a4b6b7b45bba43e968749c43ec71593a1f0d01c0R19-R37) [[2]](diffhunk://#diff-7ba3eaa1d164d54cfc3895d7672065e0a13011cfe4228ae0c0ec2f085fc5a26cR43-R61)